### PR TITLE
SDKF-1948: Integrated AddToCart event into the SDK

### DIFF
--- a/config/Info.plist
+++ b/config/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2023.02.16</string>
+	<string>2023.03.17</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/monetate-ios-sdk.podspec
+++ b/monetate-ios-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "monetate-ios-sdk"
-  s.version      = "2023.02.16"
+  s.version      = "2023.03.17"
   s.summary      = "Provides convenient access to the Engine API"
 
   # This description is used to generate tags and improve search results.
@@ -80,7 +80,7 @@ Join the 1,000+ brands growing their revenue with Kibo"
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/monetate/kibo-ios-sdk-cocoapod.git", :tag => "2023.02.16" }
+  s.source       = { :git => "https://github.com/monetate/kibo-ios-sdk-cocoapod.git", :tag => "2023.03.17" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/monetate/core/ContextMap.swift
+++ b/monetate/core/ContextMap.swift
@@ -25,6 +25,7 @@ public class ContextMap {
     
     //non trackables
     var cart:  (() -> Future<Cart, Error>)?
+    var addToCart:  (() -> Future<AddToCart, Error>)?
     var purchase:  (() -> Future<Purchase, Error>)?
     var productDetailView: (() -> Future<ProductDetailView, Error>)?
     var productThumbnailView: (() -> Future<ProductThumbnailView, Error>)?
@@ -51,6 +52,7 @@ public class ContextMap {
         screenSize: ScreenSize? = nil,
         
         cart: (() -> Future<Cart, Error>)? = nil,
+        addToCart:  (() -> Future<AddToCart, Error>)? = nil,
         purchase: (() -> Future<Purchase, Error>)? = nil,
         productDetailView: (() -> Future<ProductDetailView, Error>)? = nil,
         productThumbnailView: (() -> Future<ProductThumbnailView, Error>)? = nil,
@@ -69,6 +71,7 @@ public class ContextMap {
         
         //non auto trackables
         self.cart = cart
+        self.addToCart = addToCart
         self.productDetailView = productDetailView
         self.productThumbnailView = productThumbnailView
         self.pageView = pageView
@@ -84,6 +87,7 @@ public class ContextMap {
         
         let zip1  = Future.zip(
             cart!(),
+            addToCart!(),
             pageView!()
         )
         
@@ -100,9 +104,10 @@ public class ContextMap {
             zip1,
             zip2
         ).on(success: { (arg) in
-            let ((cart, pageView), (productDetailView, productThumbnailView, metadata, customVariables, purchase)) = arg
+            let ((cart, addToCart, pageView), (productDetailView, productThumbnailView, metadata, customVariables, purchase)) = arg
             
             let cart_str = try! JSONEncoder().encode(cart)
+            let addToCart_str = try! JSONEncoder().encode(addToCart)
             let productDetailView_str = try! JSONEncoder().encode(productDetailView)
             let productThumbnailView_str = try! JSONEncoder().encode(productThumbnailView)
             let purchase_str = try! JSONEncoder().encode(purchase)
@@ -110,7 +115,7 @@ public class ContextMap {
             let metadata_str = try! JSONEncoder().encode(metadata)
             let customVariables_str = try! JSONEncoder().encode(customVariables)
             
-            var array = [cart_str, productDetailView_str,
+            var array = [cart_str, addToCart_str, productDetailView_str,
                          productThumbnailView_str,
                          purchase_str, pageView_str,
                          metadata_str,

--- a/monetate/models/CartLine.swift
+++ b/monetate/models/CartLine.swift
@@ -28,6 +28,20 @@ public class Cart: Codable, MEvent {
     
 }
 
+/** Represents an item to be added into cart.  */
+public class AddToCart: Codable, MEvent {
+    public let eventType: String
+    public var cartLines: [CartLine]?
+    public init(cartLines: [CartLine]?) {
+        eventType = "monetate:context:AddToCart"
+        self.cartLines = cartLines
+    }
+    static func merge (first: [CartLine], second: [CartLine]) -> [CartLine] {
+        let merged = Array(Dictionary([first, second].joined().map { ($0.pid, $0)}, uniquingKeysWith: { $1 }).values)
+        return merged
+    }
+}
+
 public struct CartLine: Codable {
     
     

--- a/monetate/models/EventTypeEnum.swift
+++ b/monetate/models/EventTypeEnum.swift
@@ -26,6 +26,7 @@ public enum ContextEnum: String, MEvent {
     case EndcapClicks = "monetate:context:EndcapClicks"
     case EndcapImpressions = "monetate:context:EndcapImpressions"
     case Cart = "monetate:context:Cart"
+    case AddToCart = "monetate:context:AddToCart"
     case Purchase = "monetate:context:Purchase"
     case ProductDetailView = "monetate:context:ProductDetailView"
     case ProductThumbnailView = "monetate:context:ProductThumbnailView"

--- a/monetate/utility/Utility.swift
+++ b/monetate/utility/Utility.swift
@@ -86,6 +86,23 @@ class Utility {
                 promise.succeed(value: queue)
             }
             break
+        case .AddToCart:
+            if let key = queue[.AddToCart] as? AddToCart, let lines1 = key.cartLines, let data = data as? AddToCart, let lines2 = data.cartLines {
+                key.cartLines = AddToCart.merge(first: lines1, second: lines2)
+            } else {
+                queue[.AddToCart] = data
+            }
+            if let addToCart = contextMap.addToCart {
+                addToCart().on { (data) in
+                    if let event = queue[.AddToCart] as? AddToCart, let lines1 = event.cartLines, let lines2 = data.cartLines {
+                        event.cartLines = AddToCart.merge(first: lines1, second: lines2)
+                    }
+                    promise.succeed(value: queue)
+                }
+            } else {
+                promise.succeed(value: queue)
+            }
+            break
         case .Purchase:
             if let event = queue[.Purchase] as? Purchase, let lines1 = event.purchaseLines, let data = data as? Purchase, let lines2 = data.purchaseLines  {
                 event.purchaseLines = Purchase.merge(first: lines1, second: lines2)
@@ -183,6 +200,10 @@ class Utility {
                 json.append(data.toJSON())
             }
             if key == .Cart, let val = val as? Cart {
+                let data = try! JSONEncoder().encode(val)
+                json.append(data.toJSON())
+            }
+            if key == .AddToCart, let val = val as? AddToCart {
                 let data = try! JSONEncoder().encode(val)
                 json.append(data.toJSON())
             }


### PR DESCRIPTION
**Why**
[SDKF-1948: iOS SDK- Event Integration: Add to cart](https://kibo.atlassian.net/browse/SDKF-1948)  

**How**
Added support for [AddToCart](https://marketer.monetate.net/control/a-887f2483/p/cs.monetate.io/settings/api-docs/engine#monetate-engine-api/monetate:context:AddToCart) event into the SDK


**Validation**
Validated this functionality by sending AddToCart event into API to get decisions back from decision engine locally. 

**Demo**
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-17 at 12 42 27](https://user-images.githubusercontent.com/96769843/225883349-1e03c15f-0dfc-405c-bea0-90cb32aa6b20.png)

![Screenshot 2023-03-17 at 12 42 06 PM](https://user-images.githubusercontent.com/96769843/225883445-53781d06-6563-4692-afe5-f99240b22b10.png)


**Before**
SDK was not capable of sending AddToCart event into API for getting decisions back from decision engine.

**After**
Now SDK is capable of sending AddToCart event into API for getting decisions back from decision engine.
