### PR TITLE
SDKF-2709 Make engine host configurable

### DIFF
--- a/Sources/monetate/Resources/Version.plist
+++ b/Sources/monetate/Resources/Version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.04.06</string>
+	<string>2026.04.28</string>
 </dict>
 </plist>

--- a/Sources/monetate/core/Account.swift
+++ b/Sources/monetate/core/Account.swift
@@ -24,9 +24,9 @@ public struct Account:Codable {
         self.domain = domain
         self.name = name
         self.shortname = shortname
-        if let domain = engineHostName?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !domain.isEmpty {
-            self.engineHost = .custom(domain)
+        if let host = engineHostName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !host.isEmpty {
+            self.engineHost = .custom(host)
         } else {
             self.engineHost = .engine
         }

--- a/Sources/monetate/core/Account.swift
+++ b/Sources/monetate/core/Account.swift
@@ -13,16 +13,23 @@ public struct Account:Codable {
     private var domain: String?
     private var name: String?
     private var shortname: String?
+    private var engineHost: MonetateHostDomain
     
     /**
      Contains standard domain name instance and shortname
      */
     
-    public init(instance: String, domain:String, name:String, shortname:String) {
+    public init(instance: String, domain:String, name:String, shortname:String, engineHostName:String? = nil) {
         self.instance = instance
         self.domain = domain
         self.name = name
         self.shortname = shortname
+        if let domain = engineHostName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !domain.isEmpty {
+            self.engineHost = .custom(domain)
+        } else {
+            self.engineHost = .engine
+        }
         
         do {
             try checkAccountInfo()
@@ -72,6 +79,10 @@ public struct Account:Codable {
     
     func getDomain () -> String {
         return self.domain ?? ""
+    }
+    
+    func getEngineHost() -> MonetateHostDomain {
+        return self.engineHost
     }
 }
 

--- a/Sources/monetate/core/Personalization.swift
+++ b/Sources/monetate/core/Personalization.swift
@@ -27,7 +27,7 @@ public class Personalization {
     public init (account: Account, user: User) {
         self.account = account
         self.user = user
-        self.service = APIService(apiDomain: .engine)
+        self.service = APIService(engineHost: account.getEngineHost())
         self.timer = ScheduleTimer(timeInterval: 0.7, callback: { [weak self]  in
             _ = self?.callMonetateAPI()
         })

--- a/Sources/monetate/services/APIService.swift
+++ b/Sources/monetate/services/APIService.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// API Domain handler
-public enum MonetateAPIDomain {
+enum MonetateHostDomain: Codable {
     case engine
     case custom(String)
 
@@ -74,16 +74,16 @@ struct APIConfig {
 
 
 class APIService {
-    private let apiDomain: MonetateAPIDomain
+    private let engineHost: MonetateHostDomain
     
-    init(apiDomain: MonetateAPIDomain) {
-        self.apiDomain = apiDomain
+    init(engineHost: MonetateHostDomain) {
+        self.engineHost = engineHost
     }
     
     func getDecisionURL(account: String) -> String? {
         var components = URLComponents()
         components.scheme = APIConfig.scheme
-        components.host = apiDomain.value
+        components.host = engineHost.value
         components.path = APIConfig.Paths.decide + account
         
         return components.url?.absoluteString
@@ -92,7 +92,7 @@ class APIService {
     func getSiteSearchURL(endpoint: APIConfig.Endpoint, preRequisite: SearchPreRequisite?) -> String? {
         var components = URLComponents()
         components.scheme = APIConfig.scheme
-        components.host = apiDomain.value
+        components.host = engineHost.value
         components.path = endpoint.path(for: preRequisite?.channelData ?? "No channel")
         
         if endpoint == .urlRedirect, let actionId = preRequisite?.actionId {

--- a/config/Info.plist
+++ b/config/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.04.06</string>
+	<string>2026.04.28</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/monetate-ios-sdk.podspec
+++ b/monetate-ios-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "monetate-ios-sdk"
-  s.version      = "2026.04.06"
+  s.version      = "2026.04.28"
   s.summary      = "Provides convenient access to the Engine API"
 
   # This description is used to generate tags and improve search results.
@@ -80,7 +80,7 @@ Join the 1,000+ brands growing their revenue with Monetate"
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/monetate/monetate-personalization-ios-sdk-cocoapod.git", :tag => "2026.04.06" }
+  s.source       = { :git => "https://github.com/monetate/monetate-personalization-ios-sdk-cocoapod.git", :tag => "2026.04.28" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #


### PR DESCRIPTION
**Why** 
https://monetate.atlassian.net/browse/SDKF-2709

**How** 
Engine host made configurable from app side

**Before** 
API calls were pointed to engine.monetate.net by default

**After**
Explicit host name can pass from app side
By default engine.monetate.net will be used as host