### PR TITLE
Sdkf 2744 - Configurable Payload Logging Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.8
+import PackageDescription
+
+let package = Package(
+    name: "monetate-ios-sdk",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "Monetate",
+            targets: ["Monetate"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Monetate",
+            dependencies: [],
+            path: "Sources/monetate",
+            resources: [.process("Resources/Version.plist")]
+        ),
+        .testTarget(
+                name: "MonetateTests",
+                dependencies: ["Monetate"],
+                path: "Tests/monetateTests",
+                resources: [.process("support")]
+            )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Using Xcode:
 1. Open your project in Xcode
 2. Select File → Add Packages
 3. Enter the repository URL:
-   https://github.com/monetate/monetate-personalization-ios-sdk-binary-config.git
+   https://github.com/monetate/monetate-personalization-ios-sdk.git
 4. Choose 'main' branch or the required version
 5. Add the package to your target
 
@@ -34,7 +34,7 @@ Add the following dependency to your Package.swift file.
 
         dependencies: [
             .package(
-                url: "https://github.com/monetate/monetate-personalization-ios-sdk-binary-config.git",
+                url: " https://github.com/monetate/monetate-personalization-ios-sdk.git",
                 branch: "main"
             )
         ]

--- a/Sources/monetate/Resources/Version.plist
+++ b/Sources/monetate/Resources/Version.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleShortVersionString</key>
+    <string>2026.04.28</string>
+</dict>
+</plist>

--- a/Sources/monetate/core/Account.swift
+++ b/Sources/monetate/core/Account.swift
@@ -56,8 +56,17 @@ public struct Account:Codable {
 
     
     func getSDKVersion() -> String {
+        #if SWIFT_PACKAGE
+        guard let url = Bundle.module.url(forResource: "Version", withExtension: "plist"),
+              let dict = NSDictionary(contentsOf: url),
+              let version = dict["CFBundleShortVersionString"] as? String else {
+            return "Unknown"
+        }
+        return version
+        #else
         return Bundle(for: Personalization.self)
             .infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        #endif
     }
     
     func getChannel () -> String {

--- a/Sources/monetate/core/Personalization.swift
+++ b/Sources/monetate/core/Personalization.swift
@@ -22,12 +22,14 @@ public class Personalization {
     private let prerequisiteManager = SearchPrerequisiteManager()
     private let sdkQueue = DispatchQueue(label: "sdk.Monetate.processing", qos: .userInitiated)
     private let requestBodyCreator = RequestBodyCreator()
+    private var enableDebugMode: Bool
     
     //constructor
-    public init (account: Account, user: User) {
+    public init (account: Account, user: User, enableDebugMode: Bool = false) {
         self.account = account
         self.user = user
         self.service = APIService(engineHost: account.getEngineHost())
+        self.enableDebugMode = enableDebugMode
         self.timer = ScheduleTimer(timeInterval: 0.7, callback: { [weak self]  in
             _ = self?.callMonetateAPI()
         })
@@ -104,6 +106,9 @@ public class Personalization {
         _=callMonetateAPI()
     }
     
+    /// Update the customer ID used to identify the customer.
+    /// - Parameter customerId: The customer ID to associate with the SDK.
+    ///   The value must not be empty or contain only whitespace.
     public func setCustomerId (customerId: String) {
         guard !customerId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             Log.error(UserIdError.invalidCustomerId.localizedDescription)
@@ -111,6 +116,12 @@ public class Personalization {
         }
         self.user.setCustomerId(customerId: customerId)
         _ = self.callMonetateAPI()
+    }
+    
+    /// When enabled, the SDK will log Network payload
+    /// - Parameter enabled: Whether debug mode is enabled.
+    public func setDebugMode(_ enabled: Bool) {
+        self.enableDebugMode = enabled
     }
     /// Supported until version 2025.08.01
      /**
@@ -312,10 +323,12 @@ public class Personalization {
         
         let body:[String:Any] = buildDecisionRequestBody()
         let engineURL = service.getDecisionURL(account: account.getShortName()) ?? "Invalid URL"
-        let jsonString = body.toString ?? "JSON String conversion failed. Fallback: \(String(describing: body))"
-        
         Log.debug("Monetate Engine API URL - \(engineURL)")
-        Log.debug("Monetate Engine API body created - \(jsonString)")
+        
+        if enableDebugMode {
+            let jsonString = body.toString ?? "JSON String conversion failed. Fallback: \(String(describing: body))"
+            Log.debug("Monetate Engine API body created - \(jsonString)")
+        }
         
         self.timer?.suspend()
         service.getDecision(url: engineURL, body: body, headers: nil, success: {[weak self] (data, status, res) in

--- a/config/Info.plist
+++ b/config/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.07.10</string>
+	<string>2026.04.28</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/monetate-ios-sdk.podspec
+++ b/monetate-ios-sdk.podspec
@@ -1,0 +1,138 @@
+#
+#  Be sure to run `pod spec lint monetate-ios-sdk.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "monetate-ios-sdk"
+  s.version      = "2026.04.28"
+  s.summary      = "Provides convenient access to the Engine API"
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.description  = "Monetate Personalization, powered by Monetate and Certona, is the leading personalization software, recognized by key industry analysts.
+From sophisticated A/B testing to AI-driven personalization, harness patented technology to delight your customers with impactful individualized experiences, resulting in increased engagement, conversions, and lifetime value.
+Join the 1,000+ brands growing their revenue with Monetate"
+
+  s.homepage     = "https://www.monetate.com"
+  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = "MIT"
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author             =  "Monetate" 
+  # Or just: s.author    = "DJ DeFiccio"
+  # s.authors            = { "DJ DeFiccio" => "dj@arcweb.co" }
+  # s.social_media_url   = "http://twitter.com/DJ DeFiccio"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  s.swift_version = '5.0'
+  s.platform     = :ios, "12"
+
+  #  When using multiple platforms
+  # s.ios.deployment_target = "5.0"
+  # s.osx.deployment_target = "10.7"
+  # s.watchos.deployment_target = "2.0"
+  # s.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/monetate/monetate-personalization-ios-sdk-cocoapod.git", :tag => "2026.04.28" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "Sources/monetate/**/*.{swift,h,m}"
+  s.resources     = "Sources/monetate/Resources/*"
+
+  # s.public_header_files = "Classes/**/*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  s.framework  = "UIKit"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
+
+end

--- a/monetate-ios-sdk.xcodeproj/project.pbxproj
+++ b/monetate-ios-sdk.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		3E7924012E12918500609A04 /* SearchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7924002E12918500609A04 /* SearchData.swift */; };
 		3E7D2CA12E39194000C2F5C5 /* EventQueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7D2CA02E39194000C2F5C5 /* EventQueueManager.swift */; };
 		3E8CF1F42DC4E4760013DCAF /* ContextObj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8CF1F32DC4E4760013DCAF /* ContextObj.swift */; };
+		3E91F34B302D82CE000F038F /* Version.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3E91F34A302D82C6000F038F /* Version.plist */; };
 		46746A872AD6D388001C6A8B /* CoordinatesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46746A862AD6D388001C6A8B /* CoordinatesTest.swift */; };
 		46746A892AD83214001C6A8B /* ReferrerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46746A882AD83214001C6A8B /* ReferrerTest.swift */; };
 		46746A8B2AD98B55001C6A8B /* LanguageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46746A8A2AD98B55001C6A8B /* LanguageTest.swift */; };
@@ -160,6 +161,7 @@
 		3E7924002E12918500609A04 /* SearchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchData.swift; sourceTree = "<group>"; };
 		3E7D2CA02E39194000C2F5C5 /* EventQueueManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueueManager.swift; sourceTree = "<group>"; };
 		3E8CF1F32DC4E4760013DCAF /* ContextObj.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextObj.swift; sourceTree = "<group>"; };
+		3E91F34A302D82C6000F038F /* Version.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Version.plist; sourceTree = "<group>"; };
 		46746A862AD6D388001C6A8B /* CoordinatesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatesTest.swift; sourceTree = "<group>"; };
 		46746A882AD83214001C6A8B /* ReferrerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerTest.swift; sourceTree = "<group>"; };
 		46746A8A2AD98B55001C6A8B /* LanguageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageTest.swift; sourceTree = "<group>"; };
@@ -189,13 +191,13 @@
 		1F157C4926B02FCC000D952B /* monetate */ = {
 			isa = PBXGroup;
 			children = (
+				3E91F349302D82B0000F038F /* Resources */,
 				1F157C4A26B02FCC000D952B /* core */,
 				1F157C5126B02FCC000D952B /* Log.swift */,
 				1F157C5326B02FCC000D952B /* models */,
 				1F157C6C26B02FCC000D952B /* actions */,
 				1F157C6E26B02FCC000D952B /* services */,
 				1F157C7026B02FCC000D952B /* utility */,
-				3EDF6D132F2090B4004C9ECE /* Resources */,
 			);
 			path = monetate;
 			sourceTree = "<group>";
@@ -381,6 +383,14 @@
 			path = monetateTests;
 			sourceTree = "<group>";
 		};
+		3E91F349302D82B0000F038F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				3E91F34A302D82C6000F038F /* Version.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		3EDF6D112F208B83004C9ECE /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -395,13 +405,6 @@
 				22E0FAD0210B68D3002E6B93 /* monetateTests */,
 			);
 			path = Tests;
-			sourceTree = "<group>";
-		};
-		3EDF6D132F2090B4004C9ECE /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -502,6 +505,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3E91F34B302D82CE000F038F /* Version.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
**Why** 
https://monetate.atlassian.net/browse/SDKF-2744

**How** 
Added configurable payload logging by adding an additional parameter to the personalization initializer.

**Before**
Payload logging was not configurable from app side.

**After**
Payload logging can be restricted from the app side using the _enableDebugMode_ parameter when creating the personalization object. 
Further control can be managed using the _setDebugMode_ function call.